### PR TITLE
Update compile_hysteria.md

### DIFF
--- a/compile_hysteria.md
+++ b/compile_hysteria.md
@@ -15,7 +15,7 @@ apt install -y git python3
 ```
 
 ```
-echo -e 'export HY_APP_PLATFORMS="linux/amd64,windows/amd64"' >> /etc/environment
+echo -e 'HY_APP_PLATFORMS="linux/amd64,windows/amd64"' >> /etc/environment
 export HY_APP_PLATFORMS="linux/amd64,windows/amd64"
 echo $HY_APP_PLATFORMS
 ```


### PR DESCRIPTION
https://man.archlinux.org/man/core/pam/environment.5.en
https://man.archlinux.org/man/core/systemd/environment.d.5.en
It should not have a `export` prefix, it should be `KEY=VAULE`